### PR TITLE
internal/lsp: Remove the redundant `Server.Run()` call.

### DIFF
--- a/internal/lsp/cmd/serve.go
+++ b/internal/lsp/cmd/serve.go
@@ -78,16 +78,11 @@ func (s *Serve) Run(ctx context.Context, args ...string) error {
 		return s.forward()
 	}
 
-	// For debugging purposes only.
-	run := func(srv *lsp.Server) {
-		srv.Conn.Logger = logger(s.Trace, out)
-		go srv.Conn.Run(ctx)
-	}
 	if s.Address != "" {
-		return lsp.RunServerOnAddress(ctx, s.app.cache, s.Address, run)
+		return lsp.RunServerOnAddress(ctx, s.app.cache, s.Address, logger(s.Trace, out))
 	}
 	if s.Port != 0 {
-		return lsp.RunServerOnPort(ctx, s.app.cache, s.Port, run)
+		return lsp.RunServerOnPort(ctx, s.app.cache, s.Port, logger(s.Trace, out))
 	}
 	stream := jsonrpc2.NewHeaderStream(os.Stdin, os.Stdout)
 	srv := lsp.NewServer(s.app.cache, stream)

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -37,13 +37,13 @@ func NewServer(cache source.Cache, stream jsonrpc2.Stream) *Server {
 
 // RunServerOnPort starts an LSP server on the given port and does not exit.
 // This function exists for debugging purposes.
-func RunServerOnPort(ctx context.Context, cache source.Cache, port int, h func(s *Server)) error {
-	return RunServerOnAddress(ctx, cache, fmt.Sprintf(":%v", port), h)
+func RunServerOnPort(ctx context.Context, cache source.Cache, port int, logger jsonrpc2.Logger) error {
+	return RunServerOnAddress(ctx, cache, fmt.Sprintf(":%v", port), logger)
 }
 
-// RunServerOnPort starts an LSP server on the given port and does not exit.
+// RunServerOnAddress starts an LSP server on the given port and does not exit.
 // This function exists for debugging purposes.
-func RunServerOnAddress(ctx context.Context, cache source.Cache, addr string, h func(s *Server)) error {
+func RunServerOnAddress(ctx context.Context, cache source.Cache, addr string, logger jsonrpc2.Logger) error {
 	ln, err := net.Listen("tcp", addr)
 	if err != nil {
 		return err
@@ -55,8 +55,8 @@ func RunServerOnAddress(ctx context.Context, cache source.Cache, addr string, h 
 		}
 		stream := jsonrpc2.NewHeaderStream(conn, conn)
 		s := NewServer(cache, stream)
-		h(s)
-		go s.Run(ctx)
+		s.Conn.Logger = logger
+		s.Run(ctx)
 	}
 }
 


### PR DESCRIPTION
Besides that, use `Server.Run(Context)` as the standard way to start
the langserver.